### PR TITLE
Automate PHP manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Getting started](#getting-started)
 - [Usage](#usage)
    - [Arguments](#arguments)
+   - [Doc command](#doc-command)
 
 ## What is ddev-tinker?
 
@@ -84,5 +85,25 @@ To start your framework's REPL environment, simply type the follow:
 While this might be helpful for a quick one-off command, it's recommend to run `ddev tinker` for tinkering to avoid any Docker connection delays between multiple commands.
 
 Wrapping may also work with <kbd>"</kbd>, depending on the command used. For more consistent results between frameworks and host OS, it is recommended to use <kbd>'</kbd>. See [ddev/ddev#2547](https://github.com/ddev/ddev/issues/2547)
+
+### Doc command
+
+Out of the box, Psysh contains a `doc` command that reads "... the documentation for an object, class, constant, method or property".
+
+This add-on downloads the Psysh PHP **_English_** manual to the required location for Psysh to find it in the container.
+For other languages, manually download the file from [here](https://github.com/bobthecow/psysh/wiki/PHP-manual), and place it in your `~/.ddev/homeadditions/.local/share/psysh` folder.
+
+To use the manual, start a session and type `doc [FUNCTION_NAME]`:
+
+```shell
+$ ddev tinker
+Psy Shell v0.11.13 (PHP 8.1.21 — cli) by Justin Hileman
+> doc array_unique
+function array_unique(array $array, int $flags = 2): array
+
+Description:
+  Removes duplicate values from an array
+...
+```
 
 **Contributed and maintained by [@tyler36](https://github.com/tyler36) based on the original [ddev-contrib recipe](https://github.com/ddev/ddev-contrib/tree/master/docker-compose-services/RECIPE) by [@tyler36](https://github.com/tyler36)**

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Wrapping may also work with <kbd>"</kbd>, depending on the command used. For mor
 Out of the box, Psysh contains a `doc` command that reads "... the documentation for an object, class, constant, method or property".
 
 This add-on downloads the Psysh PHP **_English_** manual to the required location for Psysh to find it in the container.
-For other languages, manually download the file from [here](https://github.com/bobthecow/psysh/wiki/PHP-manual), and place it in your `~/.ddev/homeadditions/.local/share/psysh` folder.
+For other languages, manually download the file from [here](https://github.com/bobthecow/psysh/wiki/PHP-manual), and place it in your project's `.ddev/homeadditions/.local/share/psysh` folder.
 
 To use the manual, start a session and type `doc [FUNCTION_NAME]`:
 

--- a/install.yaml
+++ b/install.yaml
@@ -11,5 +11,9 @@ post_install_actions:
 - |
   #ddev-nodisplay
   #ddev-description:Downloading English manual ...
-  mkdir -p ~/.ddev/homeadditions/.local/share/psysh
-  curl -sSL http://psysh.org/manual/en/php_manual.sqlite -o ~/.ddev/homeadditions/.local/share/psysh/php_manual.sqlite
+  mkdir -p ./homeadditions/.local/share/psysh
+  curl -sSL http://psysh.org/manual/en/php_manual.sqlite -o ./homeadditions/.local/share/psysh/php_manual.sqlite
+
+# Shell actions that can be done during removal of the add-on
+removal_actions:
+- rm ./homeadditions/.local/share/psysh/php_manual.sqlite

--- a/install.yaml
+++ b/install.yaml
@@ -8,3 +8,8 @@ global_files:
 # DDEV environment variables can be interpolated into these actions
 post_install_actions:
 - chmod +x ~/.ddev/commands/web/tinker
+- |
+  #ddev-nodisplay
+  #ddev-description:Downloading English manual ...
+  mkdir -p ~/.ddev/homeadditions/.local/share/psysh
+  curl -sSL http://psysh.org/manual/en/php_manual.sqlite -o ~/.ddev/homeadditions/.local/share/psysh/php_manual.sqlite

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -14,7 +14,10 @@ health_checks() {
 }
 
 validate_tinker() {
+  # Output should contain outcome
   ddev tinker 'print "tinker working " . 99+1' | grep 'working 100'
+  # Manual should exist
+  test -f ${TESTDIR}/.ddev/homeadditions/.local/share/psysh/php_manual.sqlite || (printf "Failed to find manual in ${TESTDIR}\n" && exit 1)
 }
 
 teardown() {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -61,7 +61,7 @@ teardown() {
   # Get addon and test
   ddev get ${DIR}
   ddev restart
-  health_checks
+  ddev exec "curl -s https://localhost:443/ | grep Laravel"
   validate_tinker
 }
 
@@ -77,6 +77,6 @@ teardown() {
   # Get addon and test
   ddev get ${DIR}
   ddev restart
-  health_checks
+  ddev exec "curl -s https://localhost:443/ | grep Welcome"
   validate_tinker
 }


### PR DESCRIPTION
This PR downloads the Psysh PHP manual for use inside the container.

The manual is downloaded to the project level to help with testing.