### PR TITLE
Add support for CakePHP console

### DIFF
--- a/commands/web/tinker
+++ b/commands/web/tinker
@@ -37,3 +37,15 @@ if [[ "${DDEV_PROJECT_TYPE}" == *"drupal"* ]]; then
 
   exit 0
 fi
+
+if [ "${DDEV_PROJECT_TYPE}" == "cakephp" ]; then
+  # CHECK the "drush" command is available
+  if ! bin/cake --help | grep console >/dev/null; then
+    echo "Console is not available. You may need to 'ddev composer require --dev cakephp/repl'"
+    exit 1
+  fi
+
+  bin/cake console "$1"
+
+  exit 0
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -109,3 +109,25 @@ teardown() {
   ddev exec "curl -s https://localhost:443/ | grep Welcome"
   validate_tinker
 }
+
+@test "CakePHP 5 project type" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  # Setup a CakePHP 5 project
+  ddev config --project-type=cakephp --docroot=webroot
+  ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
+
+  # Get addon and test
+  ddev get ${DIR}
+  ddev restart
+  ddev exec "curl -s https://localhost:443/ | grep 'Welcome to CakePHP'"
+
+  # Add REPL. The plugin was shipped with the CakePHP app skeleton before 4.3.
+  ddev composer require --dev cakephp/repl
+  ddev cake plugin load Cake/Repl
+
+  # CakePHP console does not seem to have a "single" command output.
+  # Instead, we'll check that the "help" displays as expected to validate.
+  ddev tinker --help | grep 'This command provides a REPL'
+}


### PR DESCRIPTION
This PR adds support fo CakePHP's console package.

@see https://book.cakephp.org/5/en/console-commands/repl.html#interactive-console-repl

This PR:

- adds a nudge if the console package is not installed.
- opens console on cakephp projects.