### PR TITLE
allow non-English manual downloads

### DIFF
--- a/commands/host/get-php-manual
+++ b/commands/host/get-php-manual
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: This script is part of "tyler36/ddev-tinker". It's purpose is to download
+##              Psysh's PHP core documentation. After starting a "ddev tinker" session,
+##              type "doc date", where 'date' is any core PHP function. It will display a
+##              man-like page detailing the function.
+##              @see https://github.com/bobthecow/psysh/wiki/PHP-manual
+##              This addon does a "simple" (and naive) language check to see if the developer
+##              may prefer a different locale. See "Example" below to "fake" a non-English setup.
+## Usage: get-php-manual
+## Example: "ddev get-php-manual"
+## Example: "LANG=ja_JP.UTF8 ddev get-php-manual"
+
+mkdir -p "$DDEV_APPROOT/.ddev/homeadditions/.local/share/psysh"
+
+FILENAME=php_manual.sqlite
+BASE_URL="http://psysh.org/manual"
+
+## Parse the LANG and see if the developer has a non-English language
+case "${LANG}" in
+    de* )
+        ## Assume German from "LANG=de_DE.UTF-8"
+        MANUAL="de/$FILENAME"
+        ;;
+    fr* )
+        ## Assume French from "LANG=fr_FR.UTF-8"
+        MANUAL="fr/$FILENAME"
+        ;;
+    ja* )
+        ## Assume Japanese from "LANG=ja_JP.UTF8"
+        MANUAL="ja/$FILENAME"
+        ;;
+    ru* )
+        ## Assume Russian from "LANG=ru_RU.UTF-8"
+        MANUAL="ru/$FILENAME"
+        ;;
+    * )
+        ## Default to English
+        MANUAL="en/$FILENAME"
+        ;;
+esac
+
+curl -sSL "$BASE_URL/$MANUAL" -o "$DDEV_APPROOT/.ddev/homeadditions/.local/share/psysh/$FILENAME"

--- a/install.yaml
+++ b/install.yaml
@@ -4,14 +4,14 @@ name: ddev-tinker
 # DDEV environment variables can be interpolated into these filenames
 project_files:
 - commands/web/tinker
+- commands/host/get-php-manual
 
 # DDEV environment variables can be interpolated into these actions
 post_install_actions:
 - |
   #ddev-nodisplay
-  #ddev-description:Downloading English manual ...
-  mkdir -p ./homeadditions/.local/share/psysh
-  curl -sSL http://psysh.org/manual/en/php_manual.sqlite -o ./homeadditions/.local/share/psysh/php_manual.sqlite
+  #ddev-description:Downloading PHP core manual
+  ddev get-php-manual
 
 # Shell actions that can be done during removal of the add-on
 removal_actions:


### PR DESCRIPTION
This PR improves the installation of PHP core manual.
If $LANG starts with a recognised locale code, the manual will be downloaded in that language.

In addition, this code was extracted into a host command, thus allow developers to re-download the manual, or change the locale at any time after installation.

Note: This addon makes no claim to accuracy of the manual, especially non-English versions which are known to be incomplete and outdated. 