### PR TITLE
Add concurrency check to disable existing test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   actions: write
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
This PR cancels running tests if the branch is updated.
This prevents wasted cycles and time spent running code on outdated files.

Fixes #17