### PR TITLE
Add "release" tag to test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -67,6 +67,7 @@ teardown() {
   [ $EN_SIZE != $JA_SIZE ]
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )


### PR DESCRIPTION
This PR adds the `test_tags=release` tag.
This allows conditional running of tests based on tag presence or absence.

This requires ddev-action-add-on `v2.1.0`.